### PR TITLE
Add plugin metadata and translation loader

### DIFF
--- a/favorites-addon-wprm-wpupg.php
+++ b/favorites-addon-wprm-wpupg.php
@@ -4,9 +4,17 @@
  * Description: Limits WPUPG grids to the logged-in user’s Favorites when ?only_bookmarks=1 is set.
  * Version: 0.1.0
  * Author: MiraScully
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Text Domain: favorites-addon-wprm-wpupg
+ * License: GPL-2.0-or-later
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
+
+add_action( 'init', function() {
+    load_plugin_textdomain( 'favorites-addon-wprm-wpupg', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+} );
 
 add_filter( 'wpupg_query_post_args', function( $args, $query_args = null, $grid = null ) {
     // Only act when toggle is on.

--- a/tests/toggle_behavior_test.php
+++ b/tests/toggle_behavior_test.php
@@ -11,6 +11,8 @@ function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 
     $wp_filters[ $tag ] = $function_to_add;
 }
 
+function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {}
+
 function is_user_logged_in() {
     return true;
 }


### PR DESCRIPTION
## Summary
- add WordPress header fields (requires versions, text domain, license)
- load translation files on init
- stub `add_action` in tests to handle init hook

## Testing
- `php -l favorites-addon-wprm-wpupg.php`
- `php tests/toggle_behavior_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689550c2d8d4832b9d10b647b9b2764c