### PR TITLE
Use explicit PHP echo syntax in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Put a small GET form somewhere on the page that contains your WPUPG block. When 
 **English:**
 <form method="get" action="">
   <label>
-    <input type="checkbox" name="only_bookmarks" value="1" <?= isset($_GET['only_bookmarks']) ? 'checked' : '' ?>>
+    <input type="checkbox" name="only_bookmarks" value="1" <?php echo isset( $_GET['only_bookmarks'] ) ? 'checked' : ''; ?>>
     Only my favorites
   </label>
   <button type="submit">Apply</button>
@@ -27,7 +27,7 @@ Put a small GET form somewhere on the page that contains your WPUPG block. When 
 **Deutsch:**
 <form method="get" action="">
   <label>
-    <input type="checkbox" name="only_bookmarks" value="1" <?= isset($_GET['only_bookmarks']) ? 'checked' : '' ?>>
+    <input type="checkbox" name="only_bookmarks" value="1" <?php echo isset( $_GET['only_bookmarks'] ) ? 'checked' : ''; ?>>
     Nur meine Favoriten
   </label>
   <button type="submit">Anwenden</button>


### PR DESCRIPTION
## Summary
- Use standard PHP `<?php echo ... ?>` in README examples

## Testing
- `php tests/toggle_behavior_test.php`


------
https://chatgpt.com/codex/tasks/task_e_6895537031d4832bae667dfae86df81e